### PR TITLE
64 update dependencys name from gmcpmini to gmcplite

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Version: 2022.07.0
 Imports:
     brew,
     bslib,
-    gMCPmini,
+    gMCPLite,
     gsDesign,
     markdown,
     ragg,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gMCPShiny
 Title: gMCP Shiny App
 Type: Shiny
-Version: 2022.07.0
+Version: 2022.09.0
 Imports:
     brew,
     bslib,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,7 +5,7 @@ Modularized development will allow open source version with Merck approaches con
 1. Initial features for initial graph setup (release 1)
    - Refactor Shiny code for extensibility (modularization)
    - Replace unstable dependency `rhandsontable` with `shinyMatrix` for more robust performance, allowing to add/delete/reset rows
-   - Ensure the core graph output and code template directly depends on `gMCPmini::hGraph()`
+   - Ensure the core graph output and code template directly depends on `gMCPLite::hGraph()`
    - Save and reload .rds file for a single hGraph output
    
 1. Add features to refine UI

--- a/app.R
+++ b/app.R
@@ -3,7 +3,7 @@
 library(shiny)
 library(shinyjs)
 library(markdown)
-library(gMCPmini)
+library(gMCPLite)
 library(shinyMatrix)
 library(ragg)
 library(gsDesign)

--- a/server/graph-output.R
+++ b/server/graph-output.R
@@ -13,7 +13,7 @@ plotInput <- reactive({
   m <- df2graph(namesH = input$hypothesesMatrix[, 1], df = transitions)
   alphaHypotheses <- sapply(input$hypothesesMatrix[, "Alpha"], arithmetic_to_numeric)
 
-  gMCPmini::hGraph(
+  gMCPLite::hGraph(
     nHypotheses = nrow(input$hypothesesMatrix),
     nameHypotheses = stringi::stri_unescape_unicode(input$hypothesesMatrix[, "Name"]),
     alphaHypotheses = alphaHypotheses,

--- a/server/iterative-graph-output.R
+++ b/server/iterative-graph-output.R
@@ -117,13 +117,13 @@ SeqPlotInput <- reactive({
   alphaHypotheses <- sapply(input$hypothesesMatrix[, "Alpha"], arithmetic_to_numeric)
 
   FWER <- sum(alphaHypotheses)
-  SeqGraph <- gMCPmini::setWeights(object = gMCPmini::matrix2graph(m), weights = alphaHypotheses / FWER)
+  SeqGraph <- gMCPLite::setWeights(object = gMCPLite::matrix2graph(m), weights = alphaHypotheses / FWER)
   pval <- if (input$knowpval == "yes") GetPval() else GetReject()
-  SeqResult <- gMCPmini::gMCP(graph = SeqGraph, pvalues = pval, alpha = FWER)
+  SeqResult <- gMCPLite::gMCP(graph = SeqGraph, pvalues = pval, alpha = FWER)
 
   ngraphs <- length(SeqResult@graphs)
 
-  gMCPmini::hGraph(
+  gMCPLite::hGraph(
     nHypotheses = nrow(input$hypothesesMatrix),
     nameHypotheses = stringi::stri_unescape_unicode(input$hypothesesMatrix[, "Name"]),
     alphaHypotheses = SeqResult@graphs[[ngraphs]]@weights * FWER,

--- a/templates/call-hgraph.R
+++ b/templates/call-hgraph.R
@@ -1,4 +1,4 @@
-library(gMCPmini)
+library(gMCPLite)
 <%= if (input$plotTitle != "" | input$plotCaption != "") "library(ggplot2)\n" -%>
 
 h <- hGraph(

--- a/ui/footer.R
+++ b/ui/footer.R
@@ -5,8 +5,8 @@ tags$footer(
       width = 10, offset = 1,
       hr(),
       # Use YYYY.0M.MICRO as defined by https://calver.org/
-      p(paste("hgraph app", as.vector(read.dcf("DESCRIPTION", fields = "Version"))), class = "text-muted"),
-      p(paste("gMCPmini", packageVersion("gMCPmini")), class = "text-muted")
+      p(paste("gMCPShiny", as.vector(read.dcf("DESCRIPTION", fields = "Version"))), class = "text-muted"),
+      p(paste("gMCPLite", packageVersion("gMCPLite")), class = "text-muted")
     )
   )
 )


### PR DESCRIPTION
This PR is to

- update pkg names `gMCPmini` -> `gMCPLite`; `hgraph app` -> `gMCPShiny`
- bump version to 2022.09.0