### PR TITLE
update transition matrix module as showing all possible transitions.

### DIFF
--- a/server/display-settings.R
+++ b/server/display-settings.R
@@ -132,6 +132,9 @@ observeEvent(input$btn_node_setting_modal, {
         )
       )
     ),
+    h5("Node position", style = "margin-top: 1rem;"),
+    hr(),
+    checkboxInput("setNodepos", label = "Customize Node Position", value = rv_nodes$setNodpos, width = "100%"),
     easyClose = FALSE,
     footer = tagList(
       actionButton("btn_node_settings_save", label = "Save Settings", class = "btn-primary", icon = icon("save")),
@@ -148,6 +151,7 @@ observeEvent(input$btn_node_settings_save, {
   rv_nodes$size <- input$size
   rv_nodes$pal_name <- input$pal_name
   rv_nodes$pal_alpha <- input$pal_alpha
+  rv_nodes$setNodepos <- input$setNodepos
   removeModal()
 })
 

--- a/ui/initial/tabset-sidebar.R
+++ b/ui/initial/tabset-sidebar.R
@@ -4,6 +4,7 @@ headingPanel(
     type = "tabs",
     tabPanel(
       "Hypotheses",
+      style = "overflow-y: scroll; overflow-x: hidden; max-height: 700px",
       matrixInput(
         "hypothesesMatrix",
         label = tagList(
@@ -28,6 +29,17 @@ headingPanel(
         cols = list(names = TRUE, editableNames = FALSE, extend = FALSE)
       ),
       matrixButtonGroup("hypothesesMatrix"),
+      hr(),
+      actionButton(
+        "btn_node_setting_modal",
+        label = "More Node Settings",
+        class = "btn btn-outline-primary",
+        icon = icon("cog"),
+        width = "100%"
+      ),
+      br(),
+    conditionalPanel(
+      condition = "input.setNodepos == true",
       br(),
       matrixInput(
         "nodeposMatrix",
@@ -55,19 +67,11 @@ headingPanel(
         icon = icon("sync"),
         width = "100%",
         class = "btn btn-block btn-outline-primary"
-      ),
-      br(),
-      hr(),
-      actionButton(
-        "btn_node_setting_modal",
-        label = "More Node Settings",
-        class = "btn btn-outline-primary",
-        icon = icon("cog"),
-        width = "100%"
-      )
+      ))
     ),
     tabPanel(
       "Transitions",
+      style = "overflow-y: scroll; overflow-x: hidden; max-height: 700px",
       matrixInput("trwtMatrix",
         label = tagList(
           "Set transition weights:",

--- a/ui/initial/tabset-sidebar.R
+++ b/ui/initial/tabset-sidebar.R
@@ -87,7 +87,13 @@ headingPanel(
         rows = list(names = FALSE, editableNames = FALSE, extend = FALSE),
         cols = list(names = TRUE, editableNames = FALSE, extend = FALSE)
       ),
-      matrixButtonGroup("trwtMatrix"),
+      actionButton(
+        "btn_trwtMatrix_reset_init",
+        label = "",
+        icon = icon("sync"),
+        width = "100%",
+        class = "btn btn-block btn-outline-primary"
+      ),
       hr(),
       actionButton(
         "btn_edge_setting_modal",

--- a/ui/update/tabset-sidebar.R
+++ b/ui/update/tabset-sidebar.R
@@ -3,6 +3,7 @@ headingPanel(
   tabsetPanel(
     type = "tabs",
     tabPanel(
+      style = "overflow-y: scroll; overflow-x: hidden; max-height: 700px",
       "Testing",
       selectInput(
         inputId = "knowpval",


### PR DESCRIPTION
Per Keaven's feedback, this PR is to 

- automatically sync hypotheses names and pull out the all possible transitions as the transition weight table. [To be discussed with Keaven whether he is okay with this approach]
- ~~**Pending enhancement:**~~ make the input UI scrollable, in case the number of hypotheses becomes very large (i.e. 10 hypotheses could generate 90 possible transitions)
- hide node position table by default, add one checkbox to decide whether customize the node position in "More Node Settings" dialog